### PR TITLE
add a 'validateElement' function to ValueMissingValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Add a `validateElement` option to `ValueMissingValidator` for cases where `valueMissing` (required) isn't keyed off of `element.value` such as checkboxes [#7](https://github.com/KonnorRogers/form-associated-helpers/pull/7)
+
 ## v0.0.10
 
 - Introduce a pattern for easier translations of error messages

--- a/exports/validators/value-missing-validator.js
+++ b/exports/validators/value-missing-validator.js
@@ -3,9 +3,23 @@
  */
 
 /**
- * @type {() => import("../types.js").Validator<HTMLElement & { required?: boolean }>}
+ * @typedef {object} ValidationOptions
+ * @property {(element: HTMLElement) => boolean} validateElement - Adds the ability to determine what is considered a "value missing". A use case would be checkboxes. `ValueMissingValidator({ validateElement: (element) => Boolean(element.checked) })`
  */
-export const ValueMissingValidator = () => {
+
+/**
+ * @type {(options: Partial<ValidationOptions>) => import("../types.js").Validator<HTMLElement & { required?: boolean }>}
+ */
+export const ValueMissingValidator = (options = {}) => {
+  if (!options.validateElement) {
+    options.validateElement = (element) => Boolean(/** @type {HTMLInputElement} */(element).value)
+  }
+
+  /**
+   * @type {ValidationOptions["validateElement"]}
+   */
+  const validateElement = options.validateElement
+
   /**
    * @type {ReturnType<ValueMissingValidator>}
    */
@@ -31,7 +45,7 @@ export const ValueMissingValidator = () => {
         return validity
       }
 
-      if (!element.value) {
+      if (!validateElement(element)) {
         validity.message = (typeof obj.message === "function" ? obj.message(element) : obj.message) || ""
         validity.isValid = false
         validity.invalidKeys.push("valueMissing")

--- a/exports/validators/value-missing-validator.js
+++ b/exports/validators/value-missing-validator.js
@@ -8,7 +8,7 @@
  */
 
 /**
- * @type {(options: Partial<ValidationOptions>) => import("../types.js").Validator<HTMLElement & { required?: boolean }>}
+ * @param {Partial<ValidationOptions>} [options]
  */
 export const ValueMissingValidator = (options = {}) => {
   if (!options.validateElement) {
@@ -21,7 +21,7 @@ export const ValueMissingValidator = (options = {}) => {
   const validateElement = options.validateElement
 
   /**
-   * @type {ReturnType<ValueMissingValidator>}
+   * @type {import("../types.js").Validator<HTMLElement & { required?: boolean }>}
    */
   const obj = {
     observedAttributes: ["required"],


### PR DESCRIPTION
The use case is things like checkboxes may have a `required` attribute, but its keyed off of `checked`